### PR TITLE
set a specific node version for the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "project-celeste",
   "version": "0.0.0",
+  "engines": {
+    "node": ">=0.14.0 <15"
+  },
   "description": "The main website for the Celeste Age of Empires Online Fan Project",
   "author": "SystemGlitch",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "project-celeste",
   "version": "0.0.0",
   "engines": {
-    "node": ">=0.14.0 <15"
+    "node": ">=14 <15"
   },
   "description": "The main website for the Celeste Age of Empires Online Fan Project",
   "author": "SystemGlitch",


### PR DESCRIPTION
this keeps newer versions of node from breaking node-sass
see: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines

I imagine node has recently updated their LTS to version 16 which made github actions start using that instead of 14 and therefore breaking node-sass compatibility