### PR TITLE
2024/09/21 | Update build_prod.yml

### DIFF
--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -21,7 +21,7 @@ jobs:
       - run: rm dist/.nojekyll
       - run: mv dist/robots.prod.txt dist/robots.txt
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: dist
       - name: Delete old files


### PR DESCRIPTION
GitHub deprecated versions v1 and v2 of the actions/upload-artifact action. To fix this, we update the workflow file to use the latest version (v3) of actions/upload-artifact

https://github.com/reactjs/react.dev/issues/7148